### PR TITLE
feat: support robots.txt router

### DIFF
--- a/src/main/resources/extensions/settings.yml
+++ b/src/main/resources/extensions/settings.yml
@@ -1,0 +1,30 @@
+apiVersion: v1alpha1
+kind: Setting
+metadata:
+  name: sitemap-settings
+spec:
+  forms:
+    - group: robots
+      label: robots.txt 设置
+      formSchema:
+        - $formkit: radio
+          name: enable
+          id: enable
+          label: 启用自定义规则
+          value: true
+          options:
+            - label: 启用
+              value: true
+            - label: 关闭
+              value: false
+        - $formkit: textarea
+          if: $get(enable).value
+          name: rules
+          label: 规则
+          help: 编写 robots.txt 规则
+          rows: 10
+          value: |
+            User-agent: *
+            Allow: /
+            Disallow: /console
+

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -13,6 +13,8 @@ spec:
   homepage: https://github.com/halo-sigs/plugin-sitemap
   displayName: "Sitemap"
   description: "为站点生成站点地图"
+  settingName: sitemap-settings
+  configMapName: sitemap-configMap
   license:
     - name: "GPL-3.0"
       url: "https://github.com/halo-sigs/plugin-sitemap/blob/main/LICENSE"


### PR DESCRIPTION
示例站点: https://airbozh.tech/robots.txt

由于更希望以绝对地址来显示sitemap，所以规则设置中省去了sitemap的设置
统一设置为host/sitemap.xml，这与插件的sitemap路由一致

Resolve #18 

```release-note
新增支持 robots.txt 路由以及编辑 robots.txt 规则
```