### PR TITLE
refactor: optimize lastmod as much as possible for a fixed time

### DIFF
--- a/src/main/java/run/halo/sitemap/CachedSitemapGetter.java
+++ b/src/main/java/run/halo/sitemap/CachedSitemapGetter.java
@@ -17,7 +17,7 @@ public class CachedSitemapGetter {
         .concurrencyLevel(Runtime.getRuntime().availableProcessors())
         .initialCapacity(8)
         .maximumSize(8)
-        .expireAfterWrite(Duration.ofSeconds(30))
+        .expireAfterWrite(Duration.ofDays(1))
         .build();
 
     private final DefaultSitemapEntryLister lister;

--- a/src/main/java/run/halo/sitemap/CachedSitemapGetter.java
+++ b/src/main/java/run/halo/sitemap/CachedSitemapGetter.java
@@ -17,7 +17,7 @@ public class CachedSitemapGetter {
         .concurrencyLevel(Runtime.getRuntime().availableProcessors())
         .initialCapacity(8)
         .maximumSize(8)
-        .expireAfterWrite(Duration.ofDays(1))
+        .expireAfterWrite(Duration.ofSeconds(30))
         .build();
 
     private final DefaultSitemapEntryLister lister;

--- a/src/main/java/run/halo/sitemap/SitemapEntry.java
+++ b/src/main/java/run/halo/sitemap/SitemapEntry.java
@@ -15,7 +15,6 @@ public class SitemapEntry {
      * <p>Parent tag for each URL entry. The remaining tags are children of this tag.</p>
      * required.
      */
-    @NonNull
     private String loc;
 
     private String lastmod;

--- a/src/main/java/run/halo/sitemap/SitemapGeneratorOptions.java
+++ b/src/main/java/run/halo/sitemap/SitemapGeneratorOptions.java
@@ -53,6 +53,24 @@ public class SitemapGeneratorOptions {
     @Builder.Default
     private ChangeFreqEnum changefreq = ChangeFreqEnum.DAILY;
 
+    /**
+     * How to assign sitemap priorities:
+     * <pre>
+     * 1.0-0.8
+     * Homepage, product information, landing pages.
+     *
+     * 0.7-0.4
+     * News articles, some weather services, blog posts, category pages, pages that no site would be complete without.
+     *
+     * 0.3-0.0
+     * FAQs, outdated info, old press releases, completely static pages that are still relevant enough to keep from deleting entirely.
+     * </pre>
+     *
+     * @see
+     * <a href="https://www.contentpowered.com/blog/xml-sitemap-priority-changefreq/">xml-sitemap-priority-changefreq</a>
+     * @see
+     * <a href="https://slickplan.com/blog/xml-sitemap-priority-changefreq">xml-sitemap-priority-changefreq</a>
+     */
     @Builder.Default
     private double priority = 0.7;
 

--- a/src/main/java/run/halo/sitemap/UrlEntryMeta.java
+++ b/src/main/java/run/halo/sitemap/UrlEntryMeta.java
@@ -1,0 +1,23 @@
+package run.halo.sitemap;
+
+import io.micrometer.common.util.StringUtils;
+import java.time.Instant;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class UrlEntryMeta {
+    private String url;
+
+    private Double priority;
+
+    private Instant lastModifiedTime;
+
+    public UrlEntryMeta(String url) {
+        if (StringUtils.isBlank(url)) {
+            throw new IllegalArgumentException("url must not be blank");
+        }
+        this.url = url;
+    }
+}

--- a/src/main/java/run/halo/sitemap/UrlEntryMeta.java
+++ b/src/main/java/run/halo/sitemap/UrlEntryMeta.java
@@ -10,6 +10,9 @@ import lombok.experimental.Accessors;
 public class UrlEntryMeta {
     private String url;
 
+    /**
+     * see also {@link SitemapGeneratorOptions#getPriority()}.
+     */
     private Double priority;
 
     private Instant lastModifiedTime;

--- a/src/test/java/run/halo/sitemap/SitemapGeneratorOptionsTest.java
+++ b/src/test/java/run/halo/sitemap/SitemapGeneratorOptionsTest.java
@@ -19,23 +19,23 @@ class SitemapGeneratorOptionsTest {
         SitemapGeneratorOptions options = SitemapGeneratorOptions.builder()
             .siteUrl(new URL("https://halo.run"))
             .build();
-        SitemapEntry entry = options.transform("/about");
+        SitemapEntry entry = options.transform(new UrlEntryMeta("/about"));
         assertEquals("https://halo.run/about", entry.getLoc());
         assertEquals(ChangeFreqEnum.DAILY, entry.getChangefreq());
         assertEquals(0.7, entry.getPriority());
 
-        entry = options.transform("/archives");
+        entry = options.transform(new UrlEntryMeta("/archives"));
         assertEquals("https://halo.run/archives", entry.getLoc());
         assertEquals(ChangeFreqEnum.DAILY, entry.getChangefreq());
         assertEquals(0.7, entry.getPriority());
 
-        entry = options.transform("/categories/ümlat/>&>中");
+        entry = options.transform(new UrlEntryMeta("/categories/ümlat/>&>中"));
         assertEquals("https://halo.run/categories/%C3%BCmlat/&gt;&amp;&gt;%E4%B8%AD",
             entry.getLoc());
         assertEquals(ChangeFreqEnum.DAILY, entry.getChangefreq());
         assertEquals(0.7, entry.getPriority());
 
-        entry = options.transform("https://guqing.xyz/hello-中国<>&");
+        entry = options.transform(new UrlEntryMeta("https://guqing.xyz/hello-中国<>&"));
         assertEquals("https://guqing.xyz/hello-%E4%B8%AD%E5%9B%BD&amp;lt;&amp;gt;&amp;amp;",
             entry.getLoc());
 


### PR DESCRIPTION
### What this PR does?
优化 Sitemap 中关于文章和自定义页面的最后修改时间

how to test it?
生成 sitemap 会有缓存, 每天会重新生成一次,如果修改了文章可以重启插件让其重新生成来**测试 lastmod 的值**

/kind improvement

Fixes #10

```release-note
优化 Sitemap 中关于文章和自定义页面的最后修改时间
```